### PR TITLE
Make `node_modules` bundled with NodeJS vary less across versions

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -788,6 +788,36 @@ cd /D "{root}" && "{yarn}" {yarn_args}
     _symlink_node_modules(repository_ctx)
     _apply_post_install_patches(repository_ctx)
 
+    repository_ctx.report_progress("Removing non-deterministic *.pyc files")
+    result = repository_ctx.execute([
+        "find",
+        repository_ctx.path("node_modules"),
+        "-type",
+        "f",
+        "-name",
+        "*.pyc",
+        "-delete",
+    ])
+    if result.return_code:
+        fail("deleting .pyc files failed: %s (%s)" % (result.stdout, result.stderr))
+
+    repository_ctx.report_progress("Stripping non-deterministic debug symbols from *.node files")
+    result = repository_ctx.execute([
+        "find",
+        repository_ctx.path("node_modules"),
+        "-type",
+        "f",
+        "-name",
+        "*.node",
+        "-exec",
+        "strip",
+        "-S",
+        "{}",
+        ";",
+    ])
+    if result.return_code:
+        fail("stripping .node files failed: %s (%s)" % (result.stdout, result.stderr))
+
     _create_build_files(repository_ctx, "yarn_install", node, repository_ctx.attr.yarn_lock, repository_ctx.attr.generate_local_modules_build_files)
 
 yarn_install = repository_rule(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `node_modules` bundled with NodeJS contains non-deterministic binary files, which causes consumers of these packages to more likely have cache misses.

Issue Number: N/A


## What is the new behavior?

* `*.pyc` files are removed.
* `*.node` files are run through the `strip` tool to remove debugging symbols.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

