### PR TITLE
Use entrypoint script in `[name].runfiles/` symlink forest by default

### DIFF
--- a/internal/node/loader.js
+++ b/internal/node/loader.js
@@ -28,8 +28,7 @@ if (require.main === module) {
   // argv[0] == node, argv[1] == entry point.
   // NB: 'TEMPLATED_entry_point_path' & 'TEMPLATED_entry_point' below are replaced during the build process.
   var entryPointPath = 'TEMPLATED_entry_point_path';
-  var entryPointMain = 'TEMPLATED_entry_point_main';
-  var mainScript = process.argv[1] = entryPointMain ? `${entryPointPath}/${entryPointMain}` : entryPointPath;
+  var mainScript = process.argv[1] = entryPointPath;
   try {
     module.constructor._load(mainScript, this, /*isMain=*/true);
   } catch (e) {

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -120,9 +120,7 @@ def _write_loader_script(ctx):
     substitutions = {}
     substitutions["TEMPLATED_entry_point_path"] = _ts_to_js(_to_manifest_path(ctx, _get_entry_point_file(ctx)))
     if DirectoryFilePathInfo in ctx.attr.entry_point:
-        substitutions["TEMPLATED_entry_point_main"] = ctx.attr.entry_point[DirectoryFilePathInfo].path
-    else:
-        substitutions["TEMPLATED_entry_point_main"] = ""
+        fail("Using a directory as an entrypoint is not supported")
 
     ctx.actions.expand_template(
         template = ctx.file._loader_template,
@@ -316,18 +314,10 @@ fi
         "TEMPLATED_vendored_node": "" if is_builtin else strip_external(ctx.file._node.path),
     }
 
-    # TODO when we have "link_all_bins" we will only need to look in one place for the entry point
-    #if ctx.file.entry_point.is_source:
-    #    substitutions["TEMPLATED_script_path"] = "\"%s\"" % _to_execroot_path(ctx, ctx.file.entry_point)
-    #else:
-    #    substitutions["TEMPLATED_script_path"] = "$(rlocation \"%s\")" % _to_manifest_path(ctx, ctx.file.entry_point)
-    # For now we need to look in both places
+    substitutions["TEMPLATED_entry_point_manifest"] = _ts_to_js(_to_manifest_path(ctx, _get_entry_point_file(ctx)))
     substitutions["TEMPLATED_entry_point_execroot_path"] = "\"%s\"" % _ts_to_js(_to_execroot_path(ctx, _get_entry_point_file(ctx)))
-    substitutions["TEMPLATED_entry_point_manifest_path"] = "$(rlocation \"%s\")" % _ts_to_js(_to_manifest_path(ctx, _get_entry_point_file(ctx)))
     if DirectoryFilePathInfo in ctx.attr.entry_point:
-        substitutions["TEMPLATED_entry_point_main"] = ctx.attr.entry_point[DirectoryFilePathInfo].path
-    else:
-        substitutions["TEMPLATED_entry_point_main"] = ""
+        fail("Using a directory as an entrypoint is not supported")
 
     ctx.actions.expand_template(
         template = ctx.file._launcher_template,


### PR DESCRIPTION
Makes `nodejs_binary` and `nodejs_test` require `--enable_runfiles` to be enabled.

This change makes the resolved file path more consistent, and is a requirement for the refactored `node_modules` linker to come in a future PR.