### PR TITLE
Remove non-determistic binary files.

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -788,6 +788,33 @@ cd /D "{root}" && "{yarn}" {yarn_args}
     _symlink_node_modules(repository_ctx)
     _apply_post_install_patches(repository_ctx)
 
+    result = repository_ctx.execute([
+        "find",
+        repository_ctx.path("node_modules"),
+        "-type",
+        "f",
+        "-name",
+        "*.pyc",
+        "-delete",
+    ])
+    if result.return_code:
+        fail("deleting .pyc files failed: %s (%s)" % (result.stdout, result.stderr))
+    result = repository_ctx.execute([
+        "find",
+        repository_ctx.path("node_modules"),
+        "-type",
+        "f",
+        "-name",
+        "*.node",
+        "-exec",
+        "strip",
+        "-S",
+        "{}",
+        ";",
+    ])
+    if result.return_code:
+        fail("stripping .node files failed: %s (%s)" % (result.stdout, result.stderr))
+
     _create_build_files(repository_ctx, "yarn_install", node, repository_ctx.attr.yarn_lock, repository_ctx.attr.generate_local_modules_build_files)
 
 yarn_install = repository_rule(


### PR DESCRIPTION
`node_modules` contains non-deterministic binary files, `.pyc` from python code and `.node` from binary modules. The `.pyc` precompiled python bytecode files can be removed, and the python interpreter can be left to compile the source code on demand, and `strip` removes the non-determistic debug symbols from `.node` files.

Leaving the non-deterministic files in causes cache misses in the rules that depend on them.