### PR TITLE
node 14 m1 compat

### DIFF
--- a/internal/common/os_name.bzl
+++ b/internal/common/os_name.bzl
@@ -71,10 +71,10 @@ def is_linux_os(rctx):
 
 def node_exists_for_os(node_version, os_name):
     "Whether a node binary is available for this platform"
-    is_16_or_greater = check_version(node_version, "16.0.0")
+    is_14_or_greater = check_version(node_version, "14.0.0")
 
-    # There is no Apple Silicon native version of node before 16
-    return is_16_or_greater or os_name != "darwin_arm64"
+    # There is no Apple Silicon native version of node before 14
+    return is_14_or_greater or os_name != "darwin_arm64"
 
 def assert_node_exists_for_host(rctx):
     node_version = rctx.attr.node_version

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -570,10 +570,9 @@ if %errorlevel% neq 0 exit /b %errorlevel%
     # This template file is used by the packager tool and the pkg_npm rule.
     # `yarn publish` is not ready for use under Bazel, see https://github.com/yarnpkg/yarn/issues/610
     repository_ctx.file("run_npm.sh.template", content = """
-"{node}" "{script}" TMPL_args "$@"
+"{npm}" TMPL_args "$@"
 """.format(
-        node = repository_ctx.path(node_entry),
-        script = repository_ctx.path(npm_script),
+        npm = repository_ctx.path(npm_entry),
     ))
 
     repository_ctx.file("run_npm.bat.template", content = """


### PR DESCRIPTION
rules_nodejs does not support vendored node/yarn binaries properly. In some cases, it falls back to using binaries that it installs itself. Under x86 this is OK, but this becomes problematic on m1 since rules_nodejs does node believe that node 14 is supported natively on m1.

This patch
1. Lowers the min supported nodejs version to 14 on darwin_arm64
2. Replaces references to node/yarn installed by rules_nodejs to references to nix_nodejs