### PR TITLE
Inline repository_args script

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -171,10 +171,10 @@ if [[ "${BAZEL_NODE_PATCH_REQUIRE}" != /* ]] && [[ ! "${BAZEL_NODE_PATCH_REQUIRE
   export BAZEL_NODE_PATCH_REQUIRE=$(pwd)/${BAZEL_NODE_PATCH_REQUIRE}
 fi
 
-readonly repository_args=$(rlocation "TEMPLATED_repository_args")
+#readonly repository_args=$(rlocation "TEMPLATED_repository_args")
 readonly lcov_merger_script=$(rlocation "TEMPLATED_lcov_merger_script")
 
-source $repository_args
+export NODE_REPOSITORY_ARGS="--preserve-symlinks"
 
 ARGS=()
 LAUNCHER_NODE_OPTIONS=($NODE_REPOSITORY_ARGS)

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -260,7 +260,7 @@ fi
     runfiles.extend(ctx.files._bash_runfile_helper)
     runfiles.append(ctx.outputs.loader_script)
     runfiles.append(ctx.outputs.require_patch_script)
-    runfiles.append(ctx.file._repository_args)
+    #runfiles.append(ctx.file._repository_args)
 
     # First replace any instances of "$(rlocation " with "$$(rlocation " to preserve
     # legacy uses of "$(rlocation"
@@ -309,7 +309,7 @@ fi
         "TEMPLATED_loader_script": _to_manifest_path(ctx, ctx.outputs.loader_script),
         "TEMPLATED_modules_manifest": _to_manifest_path(ctx, node_modules_manifest),
         "TEMPLATED_node_patches_script": _to_manifest_path(ctx, ctx.file._node_patches_script),
-        "TEMPLATED_repository_args": _to_manifest_path(ctx, ctx.file._repository_args),
+        #"TEMPLATED_repository_args": _to_manifest_path(ctx, ctx.file._repository_args),
         "TEMPLATED_require_patch_script": _to_manifest_path(ctx, ctx.outputs.require_patch_script),
         "TEMPLATED_runfiles_helper_script": _to_manifest_path(ctx, ctx.file._runfile_helpers_main),
         "TEMPLATED_vendored_node": "" if is_builtin else strip_external(ctx.file._node.path),


### PR DESCRIPTION
This script has a platform-specific path and so prevents sharing cache between host!=exec and host==exec builds