### PR TITLE
Optimise copying of `data` inputs in `npm_install` and `yarn_install`

### DIFF
--- a/internal/npm_install/BUILD.bazel
+++ b/internal/npm_install/BUILD.bazel
@@ -11,8 +11,11 @@ bzl_library(
     visibility = ["//visibility:public"],
 )
 
-# Exported to be consumed for generating stardoc.
-exports_files(["npm_install.bzl"])
+exports_files([
+    "bulk_copy.sh",
+    # Exported to be consumed for generating stardoc.
+    "npm_install.bzl",
+])
 
 filegroup(
     name = "generate_build_file",

--- a/internal/npm_install/bulk_copy.sh
+++ b/internal/npm_install/bulk_copy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu -o pipefail
+
+# The list of files to copy, relative to base so directories are preserved
+input_files_list="$1"
+# The base path which input files will be resolved from
+input_files_base="$2"
+# Destination directory for files
+out_dir="$3"
+
+tar --create --file - --directory "$input_files_base"  --files-from "$input_files_list"| tar --extract --file - --directory "$out_dir"

--- a/internal/npm_install/bulk_copy.sh
+++ b/internal/npm_install/bulk_copy.sh
@@ -9,4 +9,4 @@ input_files_base="$2"
 # Destination directory for files
 out_dir="$3"
 
-tar --create --file - --directory "$input_files_base"  --files-from "$input_files_list"| tar --extract --file - --directory "$out_dir"
+tar --create --file - --directory "$input_files_base" --files-from "$input_files_list" | tar --extract --file - --directory "$out_dir"


### PR DESCRIPTION
`repository_ctx.___` actions (e.g. spawning a process, working with files) are very slow vs. most other environments. To optimise copying `data` dependencies this PR refactors `_copy_data_dependencies` to;

1. Create an input files list and write it to a file (avoids the argument length limits).
2. Performs copy in a shell script using `tar`.

`tar` was selected as;
- Easy to preserve the desired directory structure (BSD `cp` only does this for directory copying, GNU `cp` can via `--parents`).
- Built in support for an inputs list via `--files-from`.

`rsync` would likely represent a more optimal solution, however I'm not very familiar with it. It may make sense as a follow up if there is sufficient room for improvement.