### PR TITLE
Fix `copy-bulk.sh` and optimise dependencies

### DIFF
--- a/internal/npm_install/bulk_copy.sh
+++ b/internal/npm_install/bulk_copy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu -o pipefail
+set -eu
 
 # The list of files to copy, relative to base so directories are preserved
 input_files_list="$1"

--- a/internal/npm_install/bulk_copy.sh
+++ b/internal/npm_install/bulk_copy.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -eu
+set -eu -o pipefail
 
 # The list of files to copy, relative to base so directories are preserved
 input_files_list="$1"


### PR DESCRIPTION
Fixes shell usage and optimises dependency logic (gains will be more noticeable with https://github.com/bazelbuild/bazel/pull/20434).