### PR TITLE
Refactor `pkg_npm` to support caching and remove the embedded package path

### DIFF
--- a/internal/pkg_npm/npm_script_generator.js
+++ b/internal/pkg_npm/npm_script_generator.js
@@ -23,23 +23,27 @@
 const fs = require('fs');
 
 function main(args) {
-  const
-      [outDir, packPath, publishPath, runNpmTemplatePath, packBatPath, publishBatPath,
-       runNpmBatTemplatePath] = args;
+  const [
+    packPath,
+    publishPath,
+    runNpmTemplatePath,
+    packBatPath,
+    publishBatPath,
+    runNpmBatTemplatePath,
+  ] = args;
   const cwd = process.cwd();
   if (/[\//]sandbox[\//]/.test(cwd)) {
     console.error('Error: npm_script_generator must be run with no sandbox');
     process.exit(1);
   }
 
-  const npmTemplate = fs.readFileSync(runNpmTemplatePath, {encoding: 'utf-8'});
-  fs.writeFileSync(packPath, npmTemplate.replace('TMPL_args', `pack "${cwd}/${outDir}"`));
-  fs.writeFileSync(publishPath, npmTemplate.replace('TMPL_args', `publish "${cwd}/${outDir}"`));
+  const npmTemplate = fs.readFileSync(runNpmTemplatePath, { encoding: 'utf-8' });
+  fs.writeFileSync(packPath, npmTemplate.replace('TMPL_args', `pack`));
+  fs.writeFileSync(publishPath, npmTemplate.replace('TMPL_args', `publish`));
 
-  const npmBatTemplate = fs.readFileSync(runNpmBatTemplatePath, {encoding: 'utf-8'});
-  fs.writeFileSync(packBatPath, npmBatTemplate.replace('TMPL_args', `pack "${cwd}/${outDir}"`));
-  fs.writeFileSync(
-      publishBatPath, npmBatTemplate.replace('TMPL_args', `publish "${cwd}/${outDir}"`));
+  const npmBatTemplate = fs.readFileSync(runNpmBatTemplatePath, { encoding: 'utf-8' });
+  fs.writeFileSync(packBatPath, npmBatTemplate.replace('TMPL_args', `pack`));
+  fs.writeFileSync(publishBatPath, npmBatTemplate.replace('TMPL_args', `publish`));
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Removing `local` from `execution_requirements` in favour of `no-remote-exec` and `no-sandbox` so actions can be cached.

Embedded package path replaced with reference to `TreeArtifact` output (referenced via `$(location :%s)`). This also appears to address an issue where `npm pack` fails with exit code `254`, however the issue manifested as a flake so there is a chance it lingers on. Regardless, this is a safer way to reference inputs.