### PR TITLE
Match Bazel `env` attribute behaviour

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -194,8 +194,9 @@ def _nodejs_binary_impl(ctx):
     env_vars = ""
 
     # Add all env vars from the ctx attr
+    expanded_env = {}
     for [key, value] in ctx.attr.env.items():
-        env_vars += "export %s=%s\n" % (key, expand_location_into_runfiles(ctx, value, ctx.attr.data))
+        expanded_env[key] = expand_location_into_runfiles(ctx, value, ctx.attr.data)
 
     # While we can derive the workspace from the pwd when running locally
     # because it is in the execroot path `execroot/my_wksp`, on RBE the
@@ -361,6 +362,7 @@ fi
         # since this will be called from a nodejs_test, where the entrypoint is going to be the test file
         # we shouldn't add the entrypoint as a attribute to collect here
         coverage_common.instrumented_files_info(ctx, dependency_attributes = ["data"], extensions = ["js", "ts"]),
+        RunEnvironmentInfo(expanded_env),
     ]
 
 _NODEJS_EXECUTABLE_ATTRS = {

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -469,8 +469,9 @@ nodejs_binary(
         allow_files = True,
     ),
     "env": attr.string_dict(
-        doc = """Specifies additional environment variables to set when the target is executed, subject to location
-expansion.
+        doc = """
+            Specifies additional environment variables to set when the target is executed with `run` and `test`.
+            Subject to location expansion.
         """,
         default = {},
     ),


### PR DESCRIPTION
This PR;

* Fixes a bug introduced in #45 where environment variables added with the `env` were being filtered out.
* Removes reliance on codegen to forward environment variables, instead using the [`RunEnvironmentInfo`](https://bazel.build/rules/lib/providers/RunEnvironmentInfo) provider.
* Aligns `env` behaviour with behaviour defined in "common definitions" documentation (`test` and `run` only).

Since environment variables are now passed along via a provider, they won't be an input for building `nodejs_binary` and `nodejs_test` targets.

## TODO

- [ ] ~Test under `build`.~
      Does not work in `genrule`.
      According to Bazel docs, `env` was never supposed to apply to builds. This is a bug in Rules NodeJS v3.8.
- [x] Test under `test`.
- [x] Test under `run`.
- [x] Test under `run --script_path`