### PR TITLE
fix node patches in node 20.12

### DIFF
--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -63,9 +63,8 @@ function patcher$1(fs = fs__namespace, roots) {
                     return cb(err);
                 }
                 path__namespace.resolve(
-                  // node 20.12 tightened the constraints and requires the input to be a string
-                  String(args[0]),
-                );
+                // node 20.12 tightened the constraints and requires the input to be a string
+                String(args[0]));
                 if (!stats.isSymbolicLink()) {
                     return cb(null, stats);
                 }
@@ -220,9 +219,8 @@ function patcher$1(fs = fs__namespace, roots) {
     };
     fs.readdir = (...args) => {
         const p = path__namespace.resolve(
-          // node 20.12 tightened the constraints and requires the input to be a string
-          String(args[0]),
-        );
+        // node 20.12 tightened the constraints and requires the input to be a string
+        String(args[0]));
         let cb = args[args.length - 1];
         if (typeof cb !== 'function') {
             // this will likely throw callback required error.
@@ -235,8 +233,7 @@ function patcher$1(fs = fs__namespace, roots) {
             }
             // user requested withFileTypes
             if (result[0] && result[0].isSymbolicLink) {
-                Promise
-                    .all(result.map((v) => handleDirent(p, v)))
+                Promise.all(result.map((v) => handleDirent(p, v)))
                     .then(() => {
                     cb(null, result);
                 })
@@ -254,9 +251,8 @@ function patcher$1(fs = fs__namespace, roots) {
     fs.readdirSync = (...args) => {
         const res = origReaddirSync(...args);
         const p = path__namespace.resolve(
-          // node 20.12 tightened the constraints and requires the input to be a string
-          String(args[0]),
-        );
+        // node 20.12 tightened the constraints and requires the input to be a string
+        String(args[0]));
         res.forEach((v) => {
             handleDirentSync(p, v);
         });
@@ -570,21 +566,22 @@ const runfilesPathMatcher = '.runfiles';
 function inferRunfilesDirFromPath(maybeRunfilesSource) {
     while (maybeRunfilesSource !== '/') {
         if (maybeRunfilesSource.endsWith(runfilesPathMatcher)) {
-            return maybeRunfilesSource + '/';
+            return (maybeRunfilesSource + '/');
         }
         maybeRunfilesSource = path__namespace.dirname(maybeRunfilesSource);
     }
     throw new Error('Path does not contain a runfiles parent directory.');
 }
-const removeNulls = (value) => value != null;
+function removeNulls(value) {
+    return value != null;
+}
 function runfilesLocator() {
     // Sometimes cwd is under runfiles
     const cwd = process.cwd();
     // Runfiles environment variables are the preferred reference point, but can fail
-    const envRunfilesCanidates = [
-        process.env.RUNFILES_DIR,
-        process.env.RUNFILES,
-    ].filter(removeNulls).map(runfilesDir => {
+    const envRunfilesCanidates = [process.env.RUNFILES_DIR, process.env.RUNFILES]
+        .filter(removeNulls)
+        .map(runfilesDir => {
         const adjustedRunfilesDir = fs__namespace.realpathSync(runfilesDir);
         if (runfilesDir !== adjustedRunfilesDir) {
             return adjustedRunfilesDir;
@@ -634,8 +631,7 @@ VERBOSE_LOGS, } = process.env;
 if (BAZEL_PATCH_ROOTS) {
     const roots = BAZEL_PATCH_ROOTS ? BAZEL_PATCH_ROOTS.split(',') : [];
     if (VERBOSE_LOGS) {
-        console
-            .error(`bazel node patches enabled. roots: ${roots} symlinks in these directories will not escape`);
+        console.error(`bazel node patches enabled. roots: ${roots} symlinks in these directories will not escape`);
     }
     const fs = require('fs');
     patcher$1(fs, roots);
@@ -643,6 +639,6 @@ if (BAZEL_PATCH_ROOTS) {
 else if (VERBOSE_LOGS) {
     console.error(`bazel node patches disabled. set environment BAZEL_PATCH_ROOTS`);
 }
-return;/*disabled to mitigate #incident-20231108-inspiring-flourish*/// Patch subprocess logic
+// Patch subprocess logic
 const selfUnderRunfiles = resolveBundleUnderRunfiles(__filename, runfilesLocator());
 patcher(selfUnderRunfiles, NP_SUBPROCESS_NODE_DIR);

--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -639,6 +639,6 @@ if (BAZEL_PATCH_ROOTS) {
 else if (VERBOSE_LOGS) {
     console.error(`bazel node patches disabled. set environment BAZEL_PATCH_ROOTS`);
 }
-// Patch subprocess logic
+return;/*disabled to mitigate #incident-20231108-inspiring-flourish*/// Patch subprocess logic
 const selfUnderRunfiles = resolveBundleUnderRunfiles(__filename, runfilesLocator());
 patcher(selfUnderRunfiles, NP_SUBPROCESS_NODE_DIR);

--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -216,7 +216,10 @@ function patcher$1(fs = fs__namespace, roots) {
         return str;
     };
     fs.readdir = (...args) => {
-        const p = path__namespace.resolve(args[0]);
+        const p = path__namespace.resolve(
+          // node 20.12 tightened the constraints and requires the input to be a string
+          String(args[0]),
+        );
         let cb = args[args.length - 1];
         if (typeof cb !== 'function') {
             // this will likely throw callback required error.
@@ -247,7 +250,10 @@ function patcher$1(fs = fs__namespace, roots) {
     };
     fs.readdirSync = (...args) => {
         const res = origReaddirSync(...args);
-        const p = path__namespace.resolve(args[0]);
+        const p = path__namespace.resolve(
+          // node 20.12 tightened the constraints and requires the input to be a string
+          String(args[0]),
+        );
         res.forEach((v) => {
             handleDirentSync(p, v);
         });

--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -62,7 +62,10 @@ function patcher$1(fs = fs__namespace, roots) {
                 if (err) {
                     return cb(err);
                 }
-                path__namespace.resolve(args[0]);
+                path__namespace.resolve(
+                  // node 20.12 tightened the constraints and requires the input to be a string
+                  String(args[0]),
+                );
                 if (!stats.isSymbolicLink()) {
                     return cb(null, stats);
                 }


### PR DESCRIPTION
https://buildkite.com/canva-org/canva-web-build/builds/1432323#018f0aab-98b7-4ef7-8e2c-b975f8fa53ae/1464-1530

```
2024-04-23T11:21:59.249Z @canva/bazel/worker:error failed to run build: TypeError: The "paths[0]" argument must be of type string. Received an instance of Buffer
     at Object.resolve (node:path:1101:7)
     at fs.readdirSync (/mnt/ephemeral/bazel_user_root_2/a8584ebfb3d6ff0dfe61abfbfa5bb4d3/external/build_bazel_rules_nodejs/internal/node/node_patches.js:250:35)
     at _rmdirSync (node:internal/fs/rimraf:250:29)
     at rimrafSync (node:internal/fs/rimraf:193:7)
     at Object.rmSync (node:fs:1265:10)
     at buildPage (/var/lib/buildkite-agent/builds/canva__canva/web/tools/bazel/webpack/cli/webpack_cli.ts:50:6)
     at /var/lib/buildkite-agent/builds/canva__canva/web/tools/bazel/webpack/cli/webpack_cli.ts:219:5
     at runOneBuild (/var/lib/buildkite-agent/builds/canva__canva/web/tools/bazel/worker/worker_bootstrapper.ts:125:39)
     at /var/lib/buildkite-agent/builds/canva__canva/web/tools/bazel/worker/worker.ts:170:32
     at processTicksAndRejections (node:internal/process/task_queues:95:5) {
   code: 'ERR_INVALID_ARG_TYPE'
}
```

Fixes this error in node 20.12.2

output of `bazel build //tools/build/nodejs/builtins_patcher:bundle` in the monorepo run on top of https://github.com/Canva/canva/pull/495796